### PR TITLE
fix(#38): 이슈 탭에 필터가 걸린 경우 advanced 나타나지 않는 현상 수정

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -38,10 +38,17 @@ function fetchHosts() {
 function updateRegexp() {
     fetchHosts().then(hosts => {
         const rxHosts = hosts.join("|");
-        // rxIssueTab는 다음에 매칭된다: .../issues, .../issues/, .../issues?{anything}
+
+        // 다음에 매칭된다: .../issues, .../issues/, .../issues?{anything}
         rxIssueTab = new RegExp(`^https?://(www\\.)?(?:${rxHosts})/.*?/issues(?:/?$|\\?)`, "i");
+
+        // 다음에 매칭된다: .../pulls, .../pulls/
         rxPRTab = new RegExp(`^https?://(www\\.)?(?:${rxHosts})/.*?/pulls/?$`, "i");
+
+        // 다음에 매칭된다: .../issues/new?{anything}template={anything}.md{anything}
         rxNewIssuePage = new RegExp(`^https?://(www\\.)?(?:${rxHosts})/.*?/issues/new\\?.*?template=.*?\\.md`, "i");
+
+        // 다음에 매칭된다: .../issues/{any number}, .../issues/{any number}/
         rxIssueContentsPage = new RegExp(`^https?://(www\\.)?(?:${rxHosts})/.*?/issues/[0-9]+/?$`, "i");
     });
 }


### PR DESCRIPTION
관련 이슈 번호: #38 

### 작업 내용
- 이슈 탭에 필터가 걸린 경우에도 advanced가 나오도록 정규표현식 수정
- 정규 표현식 불필요한 backslash 제거