### PR TITLE
fix(#50): Encode URL params

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -257,9 +257,13 @@ function _createDropdownContents(data) {
 
     if (data.issueData) {
         for (const tempName of templateNames) {
-            const href = labels[tempName] ?
-                `${newIssueUrl}?template=${tempName}.md&labels=${labels[tempName].join(',')}`
-                : `${newIssueUrl}?template=${tempName}.md`;
+            let href = `${newIssueUrl}?template=${tempName}.md`;
+
+            if (labels[tempName]) {
+                const encodedLabels = encodeURIComponent(labels[tempName].join(","));
+                href = `${newIssueUrl}?template=${tempName}.md&labels=${encodedLabels}`;
+            }
+
             const item = `<a href=${href}>${tempName}</a>`;
 
             dropdownContents.innerHTML += item;


### PR DESCRIPTION
## 관련 이슈 
#50 

## 작업 내역
- [x] 잘못된 닫는 태그 수정
- [x] URL query params 인코딩하여 전달

### 스크린샷
없음

## 참고 사항
이제 label 내의 띄어쓰기도 인코딩되어 전달하므로 잘 동작합니다.