### PR TITLE
feat(#36): new issue 버튼을 활용하여 드랍다운 제공

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -9,6 +9,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         newIssueBtn.classList.add("sg-dropdown-btn");
         const btnParent = newIssueBtn.parentNode;
 
+        // 뒤로 가기 할 경우 태그가 추가 생성되므로, 이미 생성된 경우 방어 처리
+        if (btnParent.classList.contains("sg-dropdown-wrapper")) {
+            return;
+        }
+
         if (msg.name === "issue-contents-page-loaded") {
             _convertToSmallBtn(newIssueBtn);
         }


### PR DESCRIPTION
## 관련 이슈 
#36 

## 작업 내역
- [x] new issue 버튼에 클래스만 추가하여 드랍다운으로 사용될 수 있도록 함
- [x] 뒤로 가기 하여 접근할 경우 드랍다운이 여러 개 생성되는 버그 수정

### 스크린샷
없음

## 참고 사항
이제 new issue 버튼의 attributes가 날아가는 일이 없으므로, 깃헙에 피해(google analytics 등)를 주지 않을 것 같다.