### PR TITLE
feat(#54): zenhub과 동일한 CSS 적용

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -88,3 +88,7 @@
     line-height: 20px;
     margin-left: 5px;
 }
+
+.form-actions a.btn.sg-reset-btn {
+    margin-right: 10px;
+}


### PR DESCRIPTION
## 관련 이슈 
#54 

## 작업 내역
- [x] zenhub과 동일하게 `margin-right`을 `10px`로 지정함

### 스크린샷
![2018-04-02 9 57 42](https://user-images.githubusercontent.com/13075245/38196989-e8148178-36c0-11e8-9362-5820fc8f7b75.png)

## 참고 사항
css priority 때문에 CSS를 조금 억지로 지정하였음