### PR TITLE
Feat/#67 polish popup ui

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -54,6 +54,10 @@ a {
     font-weight: 500;
 }
 
+.sg-menu-item a {
+    color: #0645AD;
+}
+
 /* body */
 .sg-popup-body {
     font-size: 14px;

--- a/src/popup.css
+++ b/src/popup.css
@@ -9,7 +9,6 @@ a {
 }
 
 .sg-popup {
-    border-bottom: 6px solid #fc361e;
     width: 300px;
     height: 250px;
     border-radius: 2px;
@@ -86,6 +85,7 @@ a {
     font-size: 14px;
     width: 150px;
     height: 20px;
+    margin-right: 5px;
     border: none;
     outline: none;
     border-bottom: 1.5px solid #cacdda;
@@ -93,9 +93,19 @@ a {
 }
 
 .sg-popup-footer button {
-    padding: 6px;
+    margin-right: 2px;
+    padding: 2px 5px;
     font-size: 14px;
     outline: none;
-    border: none;
+    border-radius: 2px;
+    background-color: #ffffff;
     cursor: pointer;
+}
+
+.sg-popup-footer button:hover {
+    background-color: #f6f8fa;
+}
+
+.sg-popup-footer button:active {
+    background-color: #e1e4e8;
 }

--- a/src/popup.css
+++ b/src/popup.css
@@ -18,8 +18,7 @@ a {
 /* header */
 .sg-popup-header {
     border-bottom: 2px solid #cacdda;
-    padding-bottom: 2px;
-    line-height: 32px;
+    line-height: 22px;
     display: table;
 }
 
@@ -36,12 +35,13 @@ a {
     font-family: 'Ubuntu', sans-serif;
     letter-spacing: -0.5px;
     display: table-cell;
-    vertical-align: middle;
+    transform: translate(3px,-7px);
 }
 
 .sg-menu-items {
     display: block;
     float: right;
+    transform: translate(6px, -3px);
     margin-left: 7px;
 }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -23,9 +23,11 @@
                 <ul class="sg-host-list"></ul>
             </div>
             <div class="sg-popup-footer">
-                <input id="sg-host-input" type="text" placeholder="Enter a host here" spellcheck="false" tabindex="1">
-                <button id="sg-host-save">Save</button>
-                <button id="sg-host-reset">Reset</button>
+                <form id="sg-host-form">
+                    <input id="sg-host-input" type="text" placeholder="Enter a host here" spellcheck="false" tabindex="1">
+                    <button id="sg-host-save">Save</button>
+                    <button id="sg-host-reset">Reset</button>
+                </form>
             </div>
         </div>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -13,12 +13,14 @@ const resetBtn = document.getElementById("sg-host-reset");
 const input = document.getElementById("sg-host-input");
 saveBtn.addEventListener("click", saveHost);
 resetBtn.addEventListener("click", resetHost);
+document.getElementById('sg-host-form').addEventListener('submit', e => {
+    e.preventDefault();
+})
 
 function saveHost() {
     let newHost = input.value.trim();
     // 입력 받은 host에 www. 값이 있다면 제거
     newHost = newHost.replace(/^www\./, "");
-    
     if (newHost === "") {
         return;
     }


### PR DESCRIPTION
## 관련 이슈(Related issues)
https://github.com/ygnoh/smart-github/issues/67

## 작업 내역(Summary)
* 헤더쪽 아이콘 , 제목 재정렬 
* a 태그 링크컬러 변경 
* 호스트 입력 후 엔터키로도 `Save` 되게끔. 
* save, reset 버튼 위에 마우스 오버/액티브 효과 추가

### 스크린샷(Screenshots)

#### BEFORE
![image](https://user-images.githubusercontent.com/22616716/38405011-b420988a-39a8-11e8-9063-86ccc6eaa183.png)
#### AFTER
<img width="345" alt="2018-04-06 2 30 55" src="https://user-images.githubusercontent.com/22616716/38404887-014a454e-39a8-11e8-8b9a-657835992bd8.png">


## 참고 사항(Other information)
<!-- Optional -->
